### PR TITLE
Update version tests, fix :children warning

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+== 1.8.3 - 30-Aug-2020
+* Updated the tests to match the version. Thanks go to Cédric Boutillier for the spot.
+* Fixed a redefinition warning for the :children method.
+
 == 1.8.2 - 21-Jul-2020
 * Added a LICENSE file as required by the Apache-2.0 license.
 

--- a/lib/pathname2.rb
+++ b/lib/pathname2.rb
@@ -61,7 +61,7 @@ class Pathname < String
   ]
 
   facade Dir, Dir.methods(false).map{ |m| m.to_sym } - [
-    :chdir, :entries, :glob, :foreach, :mkdir, :open
+    :chdir, :entries, :glob, :foreach, :mkdir, :open, :children
   ]
 
   private
@@ -93,7 +93,7 @@ class Pathname < String
   public
 
   # The version of the pathname2 library
-  VERSION = '1.8.2'.freeze
+  VERSION = '1.8.3'.freeze
 
   # The maximum length of a path
   MAXPATH = 1024 unless defined? MAXPATH # Yes, I willfully violate POSIX

--- a/pathname2.gemspec
+++ b/pathname2.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name        = 'pathname2'
-  spec.version     = '1.8.2'
+  spec.version     = '1.8.3'
   spec.author      = 'Daniel J. Berger'
   spec.license     = 'Apache-2.0'
   spec.email       = 'djberg96@gmail.com'

--- a/test/test_version.rb
+++ b/test/test_version.rb
@@ -8,7 +8,7 @@ require 'test-unit'
 
 class TC_Pathname_Version < Test::Unit::TestCase
   test "version is set to expected value" do
-    assert_equal('1.8.1', Pathname::VERSION)
+    assert_equal('1.8.3', Pathname::VERSION)
   end
 
   test "version is frozen" do


### PR DESCRIPTION
Apparently I forgot to update the tests when I pushed out the last version. This fixes that, as well as a redefinition warning.